### PR TITLE
for issue #291

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -109,6 +109,7 @@ worker:
   links:
     - smtp:smtp
     - db:db
+    - rabbitmq:rabbitmq
   restart: on-failure:5
 
 dbbackups:

--- a/django_project/core/settings/dev.py
+++ b/django_project/core/settings/dev.py
@@ -62,7 +62,6 @@ try:
     import devserver  # noqa
     INSTALLED_APPS += (
         'devserver',
-        'django_hashedfilenamestorage',
     )
     # more details at https://github.com/dcramer/django-devserver#configuration
     DEVSERVER_DEFAULT_ADDR = '0.0.0.0'

--- a/django_project/core/settings/project.py
+++ b/django_project/core/settings/project.py
@@ -16,7 +16,8 @@ INSTALLED_APPS += (
     'localities',
     'frontend',
     'social_users',
-    'api'
+    'api',
+    'django_hashedfilenamestorage',
 )
 
 # How many versions to list in each project box

--- a/django_project/localities/models.py
+++ b/django_project/localities/models.py
@@ -549,7 +549,8 @@ class DataLoader(models.Model):
 
 # method for updating
 def load_data(sender, instance, **kwargs):
-    load_data_task.delay(instance.pk)
+    if not instance.applied:
+        load_data_task.delay(instance.pk)
 
 
 # register the signal


### PR DESCRIPTION
there is infinite loop on previous one.
i have updated new one, which handle if the data loader is still not applied, than load data automatically.

already tested with managemend command and UI without celery, and the data is loaded
but, when i tested with celere, i got 

```
[2015-11-18 01:53:18,011: ERROR/MainProcess] consumer: Cannot connect to amqp://guest:**@rabbitmq:5672//: [Errno -2] Name or service not known.
Trying again in 4.00 seconds...
```

when "make workerlogs" or "make worker"

@timlinux 
do you have advice for this? the rabbitmq is already running on docker.