### PR TITLE
Cache clusters

### DIFF
--- a/django_project/core/settings/base.py
+++ b/django_project/core/settings/base.py
@@ -44,7 +44,7 @@ USE_TZ = True
 
 # Absolute filesystem path to the directory that will hold user-uploaded files.
 # Example: "/var/www/example.com/media/"
-MEDIA_ROOT = '/home/web/media'
+MEDIA_ROOT = absolute_path('media')
 
 # URL that handles the media served from MEDIA_ROOT. Make sure to use a
 # trailing slash.
@@ -57,7 +57,7 @@ MEDIA_URL = '/media/'
 # Don't put anything in this directory yourself; store your static files
 # in apps' "static/" subdirectories and in STATICFILES_DIRS.
 # Example: "/var/www/example.com/static/"
-STATIC_ROOT = '/home/web/static'
+STATIC_ROOT = absolute_path('static')
 
 # URL prefix for static files.
 # Example: "http://example.com/static/", "http://static.example.com/"

--- a/django_project/core/settings/contrib.py
+++ b/django_project/core/settings/contrib.py
@@ -152,7 +152,7 @@ PIPELINE_ENABLED = False
 PIPELINE_CSS_COMPRESSOR = None
 PIPELINE_JS_COMPRESSOR = None
 
-BROKER_URL = 'amqp://guest:guest@%s:5672//' % os.environ['RABBITMQ_HOST']
+BROKER_URL = 'amqp://guest:guest@%s:5672//' % os.environ.get('RABBITMQ_HOST', 'localhost')
 
 CELERY_ACCEPT_CONTENT = ['json']
 CELERY_TASK_SERIALIZER = 'json'

--- a/django_project/core/settings/prod_docker.py
+++ b/django_project/core/settings/prod_docker.py
@@ -40,3 +40,7 @@ EMAIL_HOST_USER = 'noreply@healthsites.io'
 EMAIL_HOST_PASSWORD = 'docker'
 EMAIL_USE_TLS = False
 EMAIL_SUBJECT_PREFIX = '[healthsites]'
+
+# production specific environment settings
+STATIC_ROOT = '/home/web/static'
+MEDIA_ROOT = '/home/web/media'

--- a/django_project/core/settings/project.py
+++ b/django_project/core/settings/project.py
@@ -73,3 +73,5 @@ PIPELINE_CSS['project'] = {
 
 # define cluster cache directory (directory must exist)
 CLUSTER_CACHE_DIR = '/tmp'
+
+CLUSTER_CACHE_MAX_ZOOM = 5

--- a/django_project/core/settings/project.py
+++ b/django_project/core/settings/project.py
@@ -69,3 +69,7 @@ PIPELINE_CSS['project'] = {
         'media': 'screen, projection',
     },
 }
+
+
+# define cluster cache directory (directory must exist)
+CLUSTER_CACHE_DIR = '/tmp'

--- a/django_project/frontend/static/js/clusterLayer.js
+++ b/django_project/frontend/static/js/clusterLayer.js
@@ -6,6 +6,8 @@
         options: {
             url: ''
         },
+        tag: '',
+        geoname: '',
 
         initialize: function (options) {
             L.LayerGroup.prototype.initialize.call(this, []);
@@ -159,14 +161,16 @@
             }
             var bb = this._map.getBounds();
 
-            if (this._curReq && this._curReq.abort)
+            if (this._curReq && this._curReq.abort){
                 this._curReq.abort();       //prevent parallel requests
+            }
+
             var url = this.options.url + L.Util.getParamString({
                     'bbox': bb.toBBoxString(),
                     'zoom': this._map.getZoom(),
                     'iconsize': [48, 46],
                     'geoname': this.geoname,
-                    'tag': this.tag,
+                    'tag': this.tag
                 });
 
             // when using cached data we don't need to make any new requests
@@ -228,11 +232,20 @@
         },
 
         updateGeoname: function (geoname) {
-            this.geoname = geoname;
+            if (geoname) {
+                this.geoname = geoname;
+            } else {
+                this.geoname = '';
+            }
         },
 
         updateTag: function (tag) {
-            this.tag = tag;
+            if (tag) {
+                this.tag = tag;
+            } else {
+                this.tag = '';
+            }
+
         }
     });
 

--- a/django_project/localities/management/commands/gen_cluster_cache.py
+++ b/django_project/localities/management/commands/gen_cluster_cache.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+from optparse import make_option
+
+import json
+
+import os
+from django.core.management.base import BaseCommand, CommandError
+from django.conf import settings
+
+from localities.models import Locality
+
+from localities.utils import parse_bbox
+
+from localities.map_clustering import cluster
+
+
+class Command(BaseCommand):
+
+    args = '<max_zoom> <icon_size>'
+    help = 'Generate locality cluster cache'
+
+    option_list = BaseCommand.option_list + (
+        make_option(
+            '--tabs', action='store_true', dest='use_tabs', default=False,
+            help='Use when input file is tab delimited'
+        ),
+    )
+
+    def handle(self, *args, **options):
+
+        if len(args) != 2:
+            raise CommandError('Missing required arguments')
+
+        try:
+            max_zoom = int(args[0])
+            icon_size = [int(size) for size in args[1].split(',')]
+        except Exception as e:
+            raise CommandError(str(e))
+
+        if max_zoom < 0 or max_zoom > 7:
+            raise CommandError('Max zoom should be between 0 and 6')
+        if any((size < 0 for size in icon_size)):
+            # icon sizes should be positive
+            raise CommandError('Icon sizes should be positive numbers')
+        if len(icon_size) != 2:
+            raise CommandError('Icon size a comma delimited height,width')
+
+        for zoom in range(max_zoom):
+            filename = os.path.join(
+                settings.CLUSTER_CACHE_DIR,
+                '{}_{}_{}_localities.json'.format(zoom, *icon_size)
+            )
+
+            localities = Locality.objects.in_bbox(parse_bbox('-180,-90,180,90'))
+            object_list = cluster(localities, zoom, *icon_size)
+
+            with open(filename, 'wb') as cache_file:
+                json.dump(object_list, cache_file)
+
+            self.stdout.write('Generated cluster cache for zoom: %s' % zoom)

--- a/django_project/localities/management/commands/gen_cluster_cache.py
+++ b/django_project/localities/management/commands/gen_cluster_cache.py
@@ -16,7 +16,7 @@ from localities.map_clustering import cluster
 
 class Command(BaseCommand):
 
-    args = '<max_zoom> <icon_size>'
+    args = '<icon_width> <icon_height>'
     help = 'Generate locality cluster cache'
 
     option_list = BaseCommand.option_list + (
@@ -32,20 +32,15 @@ class Command(BaseCommand):
             raise CommandError('Missing required arguments')
 
         try:
-            max_zoom = int(args[0])
-            icon_size = [int(size) for size in args[1].split(',')]
+            icon_size = [int(size) for size in args[0:2]]
         except Exception as e:
             raise CommandError(str(e))
 
-        if max_zoom < 0 or max_zoom > 7:
-            raise CommandError('Max zoom should be between 0 and 6')
         if any((size < 0 for size in icon_size)):
             # icon sizes should be positive
             raise CommandError('Icon sizes should be positive numbers')
-        if len(icon_size) != 2:
-            raise CommandError('Icon size a comma delimited height,width')
 
-        for zoom in range(max_zoom):
+        for zoom in range(settings.CLUSTER_CACHE_MAX_ZOOM + 1):
             filename = os.path.join(
                 settings.CLUSTER_CACHE_DIR,
                 '{}_{}_{}_localities.json'.format(zoom, *icon_size)

--- a/django_project/localities/views.py
+++ b/django_project/localities/views.py
@@ -69,7 +69,7 @@ class LocalitiesLayer(JSONResponseMixin, ListView):
         bbox, zoom, iconsize, geoname, tag = self._parse_request_params(request)
 
         # if geoname and tag are not set we can return the cached layer
-        if not(all([geoname, tag])) and zoom < 6:
+        if not(all([geoname, tag])) and zoom <= settings.CLUSTER_CACHE_MAX_ZOOM:
             # try to read localities from disk
             filename = os.path.join(
                 settings.CLUSTER_CACHE_DIR,


### PR DESCRIPTION
Cluster cache should be pregenerated with `manage.py gen_cluster_cache 48 46`

Cluster cache is controlled by settings defined in `project.py`

Simple tests have shown that `CLUSTER_CACHE_MAX_ZOOM = 5` works the best, as higher zoom levels have too many objects that slow down the point rendering (+ there is some data transfer overhead)