### PR TITLE
Fix of TypeError: string indices must be integers, not str

### DIFF
--- a/django_project/frontend/views.py
+++ b/django_project/frontend/views.py
@@ -31,7 +31,7 @@ class MainView(TemplateView):
     def get(self, request, *args, **kwargs):
         context = self.get_context_data(**kwargs)
         context['debug'] = settings.DEBUG
-        context['locality_count'] = get_country_statistic("")['localities']
+        context['locality_count'] = json.loads(get_country_statistic(""))['localities']
         if request.user.is_authenticated():
             if request.user.is_staff:
                 context['uploader'] = True


### PR DESCRIPTION
The get_country_statistic("") method is returning a string. To access the 'localitities' key, we should first convert the string to a python dictionary

-        context['locality_count'] = get_country_statistic("")['localities']
+       context['locality_count'] = json.loads(get_country_statistic(""))['localities']