### PR TITLE
Fix of TypeError: string indices must be integers, not str (fix of the root cause)

### DIFF
--- a/django_project/localities/utils.py
+++ b/django_project/localities/utils.py
@@ -117,6 +117,9 @@ def get_country_statistic(query):
                 output = json.loads(data)
             except IOError as e:
                 try:
+                    if not os.path.exists(settings.CLUSTER_CACHE_DIR):
+                        os.makedirs(settings.CLUSTER_CACHE_DIR)
+
                     # query for each of attribute
                     healthsites = get_heathsites_master()
                     output = get_statistic(healthsites)
@@ -127,6 +130,7 @@ def get_country_statistic(query):
                     output = json.loads(output)
                 except Exception as e:
                     pass
+
 
     except Country.DoesNotExist:
         output = ""


### PR DESCRIPTION
To fix this error, just create the settings.CLUSTER_CACHE_DIR directory if it does not exists. For more informations, please read this [thread](https://github.com/healthsites/healthsites/pull/923)