### PR TITLE
fix form, unset empty tag and update electricity without Key

### DIFF
--- a/deployment/docker-osm-healthcare/mapping.yml
+++ b/deployment/docker-osm-healthcare/mapping.yml
@@ -69,7 +69,7 @@ tables:
       - key: water_source
         name: water_source
         type: string
-      - key: Key:electricity
+      - key: electricity
         name: electricity
         type: string
       - key: is_in:health_area

--- a/django_project/api/fixtures/mapping.yml
+++ b/django_project/api/fixtures/mapping.yml
@@ -69,7 +69,7 @@ tables:
       - key: water_source
         name: water_source
         type: string
-      - key: Key:electricity
+      - key: electricity
         name: electricity
         type: string
       - key: is_in:health_area

--- a/django_project/api/osm_tag_defintions.py
+++ b/django_project/api/osm_tag_defintions.py
@@ -281,11 +281,8 @@ wheelchair = {
         'Used to mark places or ways that are suitable to be used '
         'with a wheelchair and a person with a disability who uses '
         'another mobility device (like a walker)',
-    'options': [
-        'yes', 'limited', 'no', 'designated'
-    ],
     'required': False,
-    'type': str,
+    'type': bool,
 }
 
 emergency = {

--- a/django_project/api/utils.py
+++ b/django_project/api/utils.py
@@ -96,10 +96,13 @@ def is_trusted_user(user):
 def remap_dict(old_dict, transform):
     """
     Rename specific dictionary keys
+    Ignore the empty value
     """
     new_dict = {}
     for k, v in old_dict.items():
         try:
+            if v == '':
+                continue
             v = v.decode('utf-8')
         except (UnicodeDecodeError, UnicodeEncodeError, AttributeError):
             pass
@@ -146,7 +149,7 @@ def convert_to_osm_tag(mapping_file_path, data, osm_type):
                 column['name']: column['key']
             })
             if isinstance(data[column['name']], bool):
-                data[column['name']] = 'True' if data[column['name']] else 'False'
+                data[column['name']] = 'yes' if data[column['name']] else 'no'
             elif isinstance(data[column['name']], int) \
                     or isinstance(data[column['name']], float):
                 data[column['name']] = '%s' % data[column['name']]
@@ -297,9 +300,9 @@ def validate_osm_tags(osm_tags):
         elif tag_definition.get('type') == int:
             item = int(item)
         elif tag_definition.get('type') == bool:
-            if item == 'False':
+            if item == 'yes':
                 item = False
-            elif item == 'True':
+            elif item == 'no':
                 item = True
         if tag_definition['type'] == list:
             if not isinstance(item, list):

--- a/django_project/frontend/static/scripts/views/map-sidebar/healthsite-detail/detail.js
+++ b/django_project/frontend/static/scripts/views/map-sidebar/healthsite-detail/detail.js
@@ -63,9 +63,12 @@ define([
                     value = attributes[key];
                     delete attributes[key];
                 }
+                if (value) {
+                    value = value.replaceAll(';', ', ')
+                }
                 otherHtml += '<tr data-tag="' + key + '"  data-hasvalue="' + (value !== '') + '" data-required="' + definition['required'] + '">' +
                     '<td class="tag-key">' + capitalize(key.replaceAll('_', ' ')) + ' <i class="fa fa-info-circle" aria-hidden="true" title="' + description + '"></i></td>' +
-                    '<td><div class="data">' + value.replaceAll(';', ', ') + '</div></td>' +
+                    '<td><div class="data">' + value + '</div></td>' +
                     '</tr>';
             }
             return otherHtml;

--- a/django_project/frontend/static/scripts/views/map-sidebar/healthsite-detail/form.js
+++ b/django_project/frontend/static/scripts/views/map-sidebar/healthsite-detail/form.js
@@ -63,7 +63,7 @@ define([
                         inputHtml = '<input class="input" type="number" step="0.0001">';
                         break;
                     case 'boolean':
-                        options = ["True", "False"];
+                        options = ['yes', 'no'];
                     case 'string':
                         inputHtml = '<input class="input" type="text" placeholder="' + value['description'] + '" title="' + value['description'] + '" >';
                         if (!options) {


### PR DESCRIPTION
Fix some of this https://github.com/healthsites/healthsites/issues/1344
- Key:electricity is used instead of the documented tag electricity
-  the values of certain boolean (true/false) attributes are falsely set to True/False in the uploaded OSM tags. Typically, such OSM tags should read yes/no instead. Affected attributes are for example: dispensing, wheelchair, emergency, …
- when a user leaves a field in the form on healthsites.io empty, for example because they do no know the respective attribute or the health site doesn't have such an attribute, the resulting uploaded OSM features will end up having these tags anyway, only with an empty value. Here is an example: https://www.openstreetmap.org/api/0.6/changeset/80901102/download – as you can see, some tags are uploaded with empty value fields, e.g. <tag k="healthcare:speciality" v=""/>. In such situations these "unset" tags should be omitted in the uploaded changes to OSM.