### PR TITLE
[WIP] Add simple criteria based scoring functions for LocalityOSM

### DIFF
--- a/django_project/localities_osm/models/base.py
+++ b/django_project/localities_osm/models/base.py
@@ -2,6 +2,8 @@ __author__ = 'Irwan Fathurrahman <irwan@kartoza.com>'
 __date__ = '07/01/19'
 
 from django.contrib.gis.db import models
+from localities_osm.scoring.scoring_functions import \
+    generator_registry
 
 
 class LocalityOSMBase(models.Model):
@@ -9,3 +11,87 @@ class LocalityOSMBase(models.Model):
 
     class Meta:
         abstract = True
+
+
+class LocalityOSMScoreMixin:
+    """Mixin class to provide row based scoring of entry."""
+
+    def calculate_score(self):
+        raise NotImplementedError
+
+    def reset_score(self):
+        raise NotImplementedError
+
+    def is_score_calculated(self):
+        raise NotImplementedError
+
+
+class COVID19LocalityOSMScore(LocalityOSMScoreMixin):
+    """This class contains basic rules to update rows of
+    caches of attributes scores.
+
+    Rules are hardcoded now, but is expected to be taken from a json
+    serializable configurations that is stored in the database.
+    These rules might be configured by users from the admin page.
+    A rule might be associated with a django form field as widget.
+    """
+
+    # django model field for score caches
+    score_health_facility_type = models.DecimalField(
+        null=True,
+        default=0)
+    # Should add more score caches from different attributes here
+    # This one is the total score
+    total_score_covid19 = models.DecimalField(
+        null=True,
+        default=0)
+
+    # Denotes wether the score caches are already calculated
+    score_covid19_calculated = models.BooleanField(
+        null=False,
+        default=False)
+
+    _score_health_facility_definitions = {
+        'class_name': 'WeightedIndicatorScore',
+        'weight': 2,
+        'score_function': {
+            'class_name': 'KeyExistsScore',
+            'attribute_name': 'amenity',
+            'attribute_score_map': {
+                'hospital': 2,
+                'clinic': 1
+            }
+        }
+    }
+
+    _total_scoring_definitions = {
+        'class_name': 'SumAttributeScore',
+        'score_functions': [
+            _score_health_facility_definitions,
+        ]
+    }
+
+    def calculate_score(self):
+        # TODO: Should handle queryset instead of individual rows
+        class_name = self._score_health_facility_definitions['class_name']
+        scoring_function_instance = generator_registry[class_name](
+            self._score_health_facility_definitions)
+        score = scoring_function_instance.function(self)
+        self.score_health_facility_type = score
+
+        class_name = self._total_scoring_definitions['class_name']
+        scoring_function_instance = generator_registry[class_name](
+            self._total_scoring_definitions)
+        score = scoring_function_instance.function(self)
+
+        self.total_score_covid19 = score
+        self.score_covid19_calculated = True
+        self.update()
+
+    def reset_score(self):
+        # Reset scoring flag to False (need recalculate)
+        self.score_covid19_calculated = False
+        self.update()
+
+    def is_score_calculated(self):
+        return self.score_covid19_calculated

--- a/django_project/localities_osm/models/locality.py
+++ b/django_project/localities_osm/models/locality.py
@@ -2,7 +2,7 @@ __author__ = 'Irwan Fathurrahman <irwan@kartoza.com>'
 __date__ = '07/01/19'
 
 from django.contrib.gis.db import models
-from localities_osm.models.base import LocalityOSMBase
+from localities_osm.models.base import LocalityOSMBase, COVID19LocalityOSMScore
 from localities_osm.querysets import (
     PassThroughGeoManager,
     OSMQuerySet
@@ -187,7 +187,7 @@ class LocalityOSMView(LocalityOSM):
         verbose_name_plural = 'OSM Node and Way'
 
 
-class LocalityOSMNode(LocalityOSM):
+class LocalityOSMNode(LocalityOSM, COVID19LocalityOSMScore):
     """ This model is based on docker osm node
     """
     geometry = models.PointField(
@@ -200,7 +200,7 @@ class LocalityOSMNode(LocalityOSM):
         verbose_name_plural = 'OSM Node'
 
 
-class LocalityOSMWay(LocalityOSM):
+class LocalityOSMWay(LocalityOSM, COVID19LocalityOSMScore):
     """ This model is based on docker osm way
     """
     geometry = models.GeometryField(

--- a/django_project/localities_osm/scoring/scoring_functions.py
+++ b/django_project/localities_osm/scoring/scoring_functions.py
@@ -1,0 +1,87 @@
+# coding=utf-8
+import json
+
+
+class AttributeScore:
+
+    attributes = [
+        'class_name',
+    ]
+
+    def __init__(self, value):
+        if isinstance(value, basestring) or isinstance(value, str):
+            self.json_string = value
+            self.parse(value)
+        else:
+            self.dictionary = value
+            self.parse_from_dict(value)
+
+    def parse(self, json_string):
+        obj = json.loads(json_string)
+        self.parse_from_dict(obj)
+
+    def parse_from_dict(self, dictionary):
+        for key in self.attributes:
+            setattr(self, key, dictionary[key])
+
+    def function(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+class KeyExistsScore(AttributeScore):
+
+    attributes = [
+        'attribute_name',
+        'attribute_score_map',
+        'ignore_case'
+    ] + AttributeScore.attributes
+
+    def key_score_map_value(self, key):
+        ignore_case = bool(getattr(self, 'ignore_case', True))
+        for map_key, map_value in self.attribute_score_map.items():
+            if ignore_case:
+                if key.lower() == map_key.lower():
+                    return map_value
+        return 0
+
+    def function(self, value):
+        return self.key_score_map_value(getattr(value, self.attribute_name))
+
+
+class WeightedIndicatorScore(AttributeScore):
+
+    attributes = [
+        'weight',
+        'score_function',
+    ]
+
+    def function(self, value):
+        score_function_class_name = self.score_function['class_name']
+        score_function_instance = generator_registry[
+            score_function_class_name](self.score_function)
+        return self.weight * score_function_instance.function(value)
+
+
+class SumAttributeScore(AttributeScore):
+    """Composite of list of Attribute Score"""
+
+    attributes = [
+        # list of score functions
+        'score_functions',
+    ] + AttributeScore.attributes
+
+    def function(self, value):
+        sum = 0
+        for f in self.score_functions:
+            class_name = f['class_name']
+            Clazz = generator_registry[class_name]
+            score_instance = Clazz(f)
+            score = score_instance.function(value)
+            sum += score
+        return sum
+
+
+generator_registry = {
+    'KeyExistsScore': KeyExistsScore,
+    'SumAttributeScore': SumAttributeScore
+}

--- a/django_project/localities_osm/tests/test_scoring_functions.py
+++ b/django_project/localities_osm/tests/test_scoring_functions.py
@@ -1,0 +1,30 @@
+# coding=utf-8
+
+from django.test import TestCase
+from localities_osm.models.locality import LocalityOSM
+
+
+class ScoringFunctionTest(TestCase):
+
+    def setUp(self):
+        # Prepare rows of osm locality data
+        pass
+
+    def test_scoring_functions(self):
+        expected_value = {
+            'total_score_covid19': 4,
+            'score_health_facility_type': 2,
+        }
+
+        # get just one row
+        row = LocalityOSM.objects.first()
+        """:type: LocalityOSM"""
+
+        row.calculate_score()
+        row.refresh_from_db()
+
+        actual_value = {}
+        for key, value in expected_value.items():
+            actual_value[key] = getattr(row, key)
+
+        self.assertEqual(expected_value, actual_value)


### PR DESCRIPTION
For Issue #1363 

Draft PR for criteria based indicator scoring for each LocalityOSM row models.

Declare helper functions in the model to calculate score based on defined criteria.

PR aimed to tackle:

- Future changes where indicator score criteria are based on json definitions
- Json definitions of indicator score criteria can be stored in another Django Model and should be serializable
- Each indicator score functions must correspond to different widget type if it wants  to support configuration via Django Admin Form page.
- Django Admin page for this config model must generate widgets and forms according to the declared functions.
- Helper functions to calculate score in the model must be able to be executed easily via celery job
- Database trigger functions on LocalityOSM table needs to be provided to set `calculated_score` flag to False, to indicate rows that needs to be recalculated.