### PR TITLE
use social media assets from deployed production page 

### DIFF
--- a/django_project/frontend/templates/index.html
+++ b/django_project/frontend/templates/index.html
@@ -11,9 +11,9 @@
     <html itemscope itemtype="https://schema.org/Organization">
     <meta itemprop="name" content="healthsites.io">
     <meta itemprop="description" content="Building an open data commons of health facility data with OpenStreetMap">
-    <meta itemprop="image" content="https://staging.healthsites.io/static/img/healthsites-gp.png">
+    <meta itemprop="image" content="https://healthsites.io/static/img/healthsites-gp.png">
     <meta property="og:title" content="healthsites.io"/>
-    <meta property="og:image" content="https://staging.healthsites.io/static/img/healthsites-fb.png"/>
+    <meta property="og:image" content="https://healthsites.io/static/img/healthsites-fb.png"/>
     <meta property="og:description" content="Building an open data commons of health facility data with OpenStreetMap"/>
 
     <title>Healthsites.io</title>

--- a/django_project/frontend/templates/map.html
+++ b/django_project/frontend/templates/map.html
@@ -13,9 +13,9 @@
     <html itemscope itemtype="https://schema.org/Organization">
     <meta itemprop="name" content="healthsites.io">
     <meta itemprop="description" content="Building an open data commons of health facility data with OpenStreetMap">
-    <meta itemprop="image" content="https://staging.healthsites.io/static/img/healthsites-gp.png">
+    <meta itemprop="image" content="https://healthsites.io/static/img/healthsites-gp.png">
     <meta property="og:title" content="healthsites.io"/>
-    <meta property="og:image" content="https://staging.healthsites.io/static/img/healthsites-fb.png"/>
+    <meta property="og:image" content="https://healthsites.io/static/img/healthsites-fb.png"/>
     <meta property="og:description" content="Building an open data commons of health facility data with OpenStreetMap"/>
 
     <title>Healthsites.io</title>


### PR DESCRIPTION
Instead of requesting them from staging.healthsites.io, which doesn't even have a valid https certificate at the moment: https://staging.healthsites.io/static/img/healthsites-gp.png

![](https://staging.healthsites.io/static/img/healthsites-gp.png)

