### PR TITLE
Use preferred tile.openstreetmap.org URL

### DIFF
--- a/django_project/frontend/static/js/views/map/map.js
+++ b/django_project/frontend/static/js/views/map/map.js
@@ -15,8 +15,8 @@ define([
                 this.MAP.setView([0, 0], 2);
             }
 
-            this.osm = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-                attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+            this.osm = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
             });
             this.aerial_map = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
                 attribution:


### PR DESCRIPTION
I would like to suggest using the now preferred https://tile.openstreetmap.org URL instead of the current one (`{s}`), see

https://github.com/openstreetmap/operations/issues/737