### PR TITLE
Small change to display map again

### DIFF
--- a/django_project/core/static/css/map.css
+++ b/django_project/core/static/css/map.css
@@ -447,7 +447,7 @@ html, body {
 @media only screen and (max-width: 991px) {
     .map-page {
         background: #c8e6ff;
-        position: absolute;
+        position: absolute !important;
         top: 0;
         right: 0;
         left: 0;


### PR DESCRIPTION
On phones the map was hidden behind the location info because bootstrap decided it should be `position: relative`. A cheeky `!important` changed that. 