### PR TITLE
Expand Behave URL coverage

### DIFF
--- a/deployment/docker/REQUIREMENTS-dev.txt
+++ b/deployment/docker/REQUIREMENTS-dev.txt
@@ -7,6 +7,9 @@ factory_boy
 
 django-devserver
 
+# behaviour-driven tests
+behave==1.2.6
+
 # documentation
 Sphinx
 

--- a/deployment/docker/REQUIREMENTS.txt
+++ b/deployment/docker/REQUIREMENTS.txt
@@ -19,3 +19,6 @@ pyshp==2.1.3
 PyYAML==6.0
 raven==6.10.0
 social-auth-app-django==5.4.1
+
+# behaviour-driven tests
+behave==1.2.6

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,0 +1,48 @@
+"""Behave test environment for the Healthsites Django project."""
+import os
+import sys
+from pathlib import Path
+
+import django
+from django.test.runner import DiscoverRunner
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DJANGO_PROJECT_PATH = PROJECT_ROOT / 'django_project'
+
+if str(DJANGO_PROJECT_PATH) not in sys.path:
+    sys.path.insert(0, str(DJANGO_PROJECT_PATH))
+
+
+def before_all(context):
+    """Initialise Django so behave can use the ORM and test client."""
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'core.settings.tests')
+    django.setup()
+    context.test_runner = DiscoverRunner()
+    context.test_runner.setup_test_environment()
+    context.databases = context.test_runner.setup_databases()
+
+
+def after_all(context):
+    """Tear down the Django testing environment and databases."""
+    context.test_runner.teardown_databases(context.databases)
+    context.test_runner.teardown_test_environment()
+
+
+def after_feature(context, feature):
+    """Ensure URL-based features exercised every discovered path."""
+    if getattr(context, 'url_tracking_initialised', False):
+        missing = sorted(context.remaining_urls)
+        assert not missing, (
+            'Missing Behave scenarios for the following URLs: ' + ', '.join(missing)
+        )
+        del context.remaining_urls
+        del context.testable_urls
+        context.url_tracking_initialised = False
+
+
+def before_scenario(context, scenario):
+    """Provide a Django test client for each scenario."""
+    from django.test import Client
+
+    context.client = Client()

--- a/features/steps/url_steps.py
+++ b/features/steps/url_steps.py
@@ -1,0 +1,36 @@
+"""Behave steps for URL availability checks."""
+from __future__ import annotations
+
+from behave import given, then, when
+
+from features.url_utils import collect_testable_urls
+
+SUCCESS_MAX_STATUS = 399
+
+
+@given('the list of non-parameterized URLs is prepared')
+def gather_urls(context):
+    if getattr(context, 'url_tracking_initialised', False):
+        return
+    context.testable_urls = collect_testable_urls()
+    assert context.testable_urls, 'No URLs discovered to test.'
+    context.remaining_urls = set(context.testable_urls)
+    context.url_tracking_initialised = True
+
+
+@when('I request "{url}"')
+def request_url(context, url):
+    assert hasattr(context, 'testable_urls'), 'URL list has not been prepared.'
+    assert url in context.testable_urls, f'Unknown URL requested: {url}'
+    context.current_url = url
+    context.response = context.client.get(url, follow=True)
+    context.remaining_urls.discard(url)
+
+
+@then('the response should return a successful status code')
+def assert_successful_status_codes(context):
+    response = getattr(context, 'response', None)
+    assert response is not None, 'No response recorded for this scenario.'
+    assert response.status_code <= SUCCESS_MAX_STATUS, (
+        f"{context.current_url} -> {response.status_code}"
+    )

--- a/features/url_accessibility.feature
+++ b/features/url_accessibility.feature
@@ -1,0 +1,127 @@
+Feature: URL availability
+  Healthsites exposes many Django URL patterns. This feature guards against
+  accidental regressions by confirming that every URL that does not require
+  path parameters can still be requested successfully.
+
+  Background:
+    Given the list of non-parameterized URLs is prepared
+
+  Scenario: / responds successfully
+    When I request "/"
+    Then the response should return a successful status code
+
+  Scenario: /about responds successfully
+    When I request "/about"
+    Then the response should return a successful status code
+
+  Scenario: /admin/core/sitepreferences/ responds successfully
+    When I request "/admin/core/sitepreferences/"
+    Then the response should return a successful status code
+
+  Scenario: /api/docs/ responds successfully
+    When I request "/api/docs/"
+    Then the response should return a successful status code
+
+  Scenario: /api/public/countries/autocomplete responds successfully
+    When I request "/api/public/countries/autocomplete"
+    Then the response should return a successful status code
+
+  Scenario: /api/public/csv-import-progress/ responds successfully
+    When I request "/api/public/csv-import-progress/"
+    Then the response should return a successful status code
+
+  Scenario: /api/public/facilities/ responds successfully
+    When I request "/api/public/facilities/"
+    Then the response should return a successful status code
+
+  Scenario: /api/public/facilities/autocomplete/ responds successfully
+    When I request "/api/public/facilities/autocomplete/"
+    Then the response should return a successful status code
+
+  Scenario: /api/public/facilities/cluster responds successfully
+    When I request "/api/public/facilities/cluster"
+    Then the response should return a successful status code
+
+  Scenario: /api/public/facilities/count responds successfully
+    When I request "/api/public/facilities/count"
+    Then the response should return a successful status code
+
+  Scenario: /api/public/facilities/statistic responds successfully
+    When I request "/api/public/facilities/statistic"
+    Then the response should return a successful status code
+
+  Scenario: /api/public/search/geoname responds successfully
+    When I request "/api/public/search/geoname"
+    Then the response should return a successful status code
+
+  Scenario: /api/schema/ responds successfully
+    When I request "/api/schema/"
+    Then the response should return a successful status code
+
+  Scenario: /api/v1/ responds successfully
+    When I request "/api/v1/"
+    Then the response should return a successful status code
+
+  Scenario: /api/v2/ responds successfully
+    When I request "/api/v2/"
+    Then the response should return a successful status code
+
+  Scenario: /api/v3/facilities/ responds successfully
+    When I request "/api/v3/facilities/"
+    Then the response should return a successful status code
+
+  Scenario: /api/v3/facilities/statistic/ responds successfully
+    When I request "/api/v3/facilities/statistic/"
+    Then the response should return a successful status code
+
+  Scenario: /api/v3/user/ responds successfully
+    When I request "/api/v3/user/"
+    Then the response should return a successful status code
+
+  Scenario: /attributions responds successfully
+    When I request "/attributions"
+    Then the response should return a successful status code
+
+  Scenario: /contact responds successfully
+    When I request "/contact"
+    Then the response should return a successful status code
+
+  Scenario: /donate responds successfully
+    When I request "/donate"
+    Then the response should return a successful status code
+
+  Scenario: /enrollment/form responds successfully
+    When I request "/enrollment/form"
+    Then the response should return a successful status code
+
+  Scenario: /help responds successfully
+    When I request "/help"
+    Then the response should return a successful status code
+
+  Scenario: /how-to-gather responds successfully
+    When I request "/how-to-gather"
+    Then the response should return a successful status code
+
+  Scenario: /logout/ responds successfully
+    When I request "/logout/"
+    Then the response should return a successful status code
+
+  Scenario: /map responds successfully
+    When I request "/map"
+    Then the response should return a successful status code
+
+  Scenario: /profile/ responds successfully
+    When I request "/profile/"
+    Then the response should return a successful status code
+
+  Scenario: /profile-update/ responds successfully
+    When I request "/profile-update/"
+    Then the response should return a successful status code
+
+  Scenario: /signin/ responds successfully
+    When I request "/signin/"
+    Then the response should return a successful status code
+
+  Scenario: /upload-form responds successfully
+    When I request "/upload-form"
+    Then the response should return a successful status code

--- a/features/url_utils.py
+++ b/features/url_utils.py
@@ -1,0 +1,70 @@
+"""Helpers for collecting project-owned Django URL patterns."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List, Union
+
+from django.urls import URLPattern, URLResolver, get_resolver
+from django.urls.resolvers import RegexPattern, RoutePattern
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DJANGO_PROJECT_ROOT = PROJECT_ROOT / 'django_project'
+
+
+def _is_parameterized(pattern: URLPattern) -> bool:
+    fragment = pattern.pattern
+    if isinstance(fragment, RoutePattern):
+        return bool(fragment.converters)
+    return fragment.regex.groups > 0
+
+
+def _pattern_to_text(
+    pattern_fragment: Union[RoutePattern, RegexPattern]
+) -> str:
+    if isinstance(pattern_fragment, RoutePattern):
+        return pattern_fragment.pattern
+    text = pattern_fragment.regex.pattern
+    return text.lstrip('^').rstrip('$')
+
+
+def _normalise(path: str) -> str:
+    if not path:
+        return '/'
+    return '/' + path.lstrip('/')
+
+
+def _resolver_is_project_owned(resolver: URLResolver) -> bool:
+    module = resolver.urlconf_module
+    modules = module if isinstance(module, (list, tuple)) else [module]
+    for candidate in modules:
+        module_file = getattr(candidate, '__file__', None)
+        if module_file is None:
+            return True
+        try:
+            Path(module_file).resolve().relative_to(DJANGO_PROJECT_ROOT)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def _collect_urls(patterns: Iterable, prefix: str = '') -> List[str]:
+    """Recursively collect URL patterns that do not require parameters."""
+    collected: List[str] = []
+    for entry in patterns:
+        if isinstance(entry, URLPattern):
+            if _is_parameterized(entry):
+                continue
+            fragment = _pattern_to_text(entry.pattern)
+            collected.append(_normalise(prefix + fragment))
+        elif isinstance(entry, URLResolver):
+            if not _resolver_is_project_owned(entry):
+                continue
+            fragment = _pattern_to_text(entry.pattern)
+            collected.extend(_collect_urls(entry.url_patterns, prefix + fragment))
+    return collected
+
+
+def collect_testable_urls() -> List[str]:
+    resolver = get_resolver()
+    return sorted(set(_collect_urls(resolver.url_patterns)))


### PR DESCRIPTION
## Summary
- restructure the Behave steps so each scenario hits a single URL and track coverage across the feature run
- add a reusable helper that gathers all project-owned, non-parameterized URLs while skipping third-party resolvers
- expand the URL availability feature to enumerate every discovered URL as its own scenario

## Testing
- Not run (Django/Behave dependencies are unavailable in this execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dc816d874832a96018d7bde69d395)