### PR TITLE
Add InfraScan audit workflow for security scanning

### DIFF
--- a/.github/workflows/infrascan.yml
+++ b/.github/workflows/infrascan.yml
@@ -1,0 +1,32 @@
+name: InfraScan Audit
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  infrascan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create Reports Directory
+        run: |
+          mkdir -p infrascan-reports
+          chmod 777 infrascan-reports
+
+      - name: Run InfraScan
+        uses: soldevelo/infrascan@v1.0.6
+        with:
+          scanner: comprehensive
+          format: html
+          out: infrascan-reports/report.html
+            
+      - name: Upload InfraScan Report
+        uses: actions/upload-artifact@v4
+        if: always() # Upload report even if the scan step fails
+        with:
+          name: infrascan-report
+          path: infrascan-reports/report.html
+          retention-days: 14


### PR DESCRIPTION
## Description

This PR introduces an automated InfraScan GitHub Actions workflow to the **healthsites** repository in order to continuously scan infrastructure and deployment configurations for security vulnerabilities, outdated container images, and potential misconfigurations.

The workflow runs on every `push` and `pull_request` event and executes a comprehensive InfraScan analysis of Docker and infrastructure definitions. It generates an HTML report and uploads it as a GitHub Actions artifact for later review.

This change is a follow-up to the findings reported in the Issues:
https://github.com/healthsites/healthsites/issues/1563

The referenced scan identified multiple outdated and vulnerable Docker images in deployment configurations, including:
- deprecated RabbitMQ image versions with known CVEs,
- outdated PostGIS/Kartoza database images with accumulated vulnerabilities,
- unpinned or outdated Nginx image usage,
- general lack of explicit version pinning in some services.

The full InfraScan report used as a reference is available here:
https://infrascan.soldevelo.com/?scan_id=4b46a384-ab65-46a7-9366-ac28ff4eb8f3

By introducing this workflow, the repository gains continuous security validation in CI/CD, ensuring that vulnerable or outdated container images are detected early and cannot be reintroduced unnoticed in future changes.